### PR TITLE
Handle unlabelled ts files

### DIFF
--- a/src/datasets/data.py
+++ b/src/datasets/data.py
@@ -292,8 +292,12 @@ class TSRegressionArchive(BaseData):
             labels_df = pd.DataFrame(labels.cat.codes, dtype=np.int8)  # int8-32 gives an error when using nn.CrossEntropyLoss
         else:  # e.g. imputation
             try:
-                df, labels = load_data.load_from_tsfile_to_dataframe(filepath, return_separate_X_and_y=True,
+                data = load_data.load_from_tsfile_to_dataframe(filepath, return_separate_X_and_y=True,
                                                                      replace_missing_vals_with='NaN')
+                if isinstance(data, tuple):
+                    df, labels = data
+                else:
+                    df = data
             except:
                 df, _ = utils.load_from_tsfile_to_dataframe(filepath, return_separate_X_and_y=True,
                                                                  replace_missing_vals_with='NaN')

--- a/src/datasets/utils.py
+++ b/src/datasets/utils.py
@@ -91,6 +91,7 @@ def load_from_tsfile_to_dataframe(full_file_path_and_name, return_separate_X_and
     instance_list = []
     class_val_list = []
     line_num = 0
+    target_labels = False
 
     # Parse the file
     # print(full_file_path_and_name)


### PR DESCRIPTION
Thanks for this code and the paper!

I found an issue when working with the ts file format - if I was using unlabelled data and so defined `@classlabel false` in the header section of the file then it would throw an exception when running.  The issue is that the return from `load_from_tsfile_to_dataframe` will return a tuple when `@classlabel` is `true`, but just the dataframe when `@classlabel` is `false`. Therefore, when  unpacking the expected from `load_from_tsfile_to_dataframe` it would throw an exception, and fall back to your implementation, however this assumes that the last column is a label and you end up with a truncated data set. 