### PR TITLE
M2 / sktime 0.22 / Python 3.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ tensorboard
 matplotlib
 numpy
 scikit_learn
-sktime==0.4.1
+sktime

--- a/src/datasets/data.py
+++ b/src/datasets/data.py
@@ -9,7 +9,7 @@ from itertools import repeat, chain
 import numpy as np
 import pandas as pd
 from tqdm import tqdm
-from sktime.utils import load_data
+from sktime.datasets import load_from_tsfile_to_dataframe
 
 from datasets import utils
 
@@ -283,10 +283,10 @@ class TSRegressionArchive(BaseData):
         # Every row of the returned df corresponds to a sample;
         # every column is a pd.Series indexed by timestamp and corresponds to a different dimension (feature)
         if self.config['task'] == 'regression':
-            df, labels = utils.load_from_tsfile_to_dataframe(filepath, return_separate_X_and_y=True, replace_missing_vals_with='NaN')
+            df, labels = load_from_tsfile_to_dataframe(filepath, return_separate_X_and_y=True, replace_missing_vals_with='NaN')
             labels_df = pd.DataFrame(labels, dtype=np.float32)
         elif self.config['task'] == 'classification':
-            df, labels = load_data.load_from_tsfile_to_dataframe(filepath, return_separate_X_and_y=True, replace_missing_vals_with='NaN')
+            df, labels = load_from_tsfile_to_dataframe(filepath, return_separate_X_and_y=True, replace_missing_vals_with='NaN')
             labels = pd.Series(labels, dtype="category")
             self.class_names = labels.cat.categories
             labels_df = pd.DataFrame(labels.cat.codes, dtype=np.int8)  # int8-32 gives an error when using nn.CrossEntropyLoss
@@ -299,7 +299,7 @@ class TSRegressionArchive(BaseData):
                 else:
                     df = data
             except:
-                df, _ = utils.load_from_tsfile_to_dataframe(filepath, return_separate_X_and_y=True,
+                df, _ = load_from_tsfile_to_dataframe(filepath, return_separate_X_and_y=True,
                                                                  replace_missing_vals_with='NaN')
             labels_df = None
 

--- a/src/datasets/data.py
+++ b/src/datasets/data.py
@@ -9,9 +9,8 @@ from itertools import repeat, chain
 import numpy as np
 import pandas as pd
 from tqdm import tqdm
-from sktime.datasets import load_from_tsfile_to_dataframe
 
-from datasets import utils
+from .utils import load_from_tsfile_to_dataframe
 
 logger = logging.getLogger('__main__')
 

--- a/src/main.py
+++ b/src/main.py
@@ -193,10 +193,12 @@ def main(config):
                                  collate_fn=lambda x: collate_fn(x, max_len=model.max_len))
         test_evaluator = runner_class(model, test_loader, device, loss_module,
                                             print_interval=config['print_interval'], console=config['console'])
-        aggr_metrics_test, per_batch_test = test_evaluator.evaluate(keep_all=True)
+        with torch.no_grad():
+            aggr_metrics_test, per_batch_test = test_evaluator.evaluate(keep_all=True)
         print_str = 'Test Summary: '
         for k, v in aggr_metrics_test.items():
-            print_str += '{}: {:8f} | '.format(k, v)
+            if v is not None:
+                print_str += '{}: {:8f} | '.format(k, v)
         logger.info(print_str)
         return
     


### PR DESCRIPTION
I was able to get the regression example running with the following branches, plus a weird monkey patch on PyTorch, which was to remove the `is_causal=is_causal` flag on line 315 in `transformers.py`. (Apparently `is_causal` is a hint, but PyTorch kept on complaining how `is_causal` was an unexpected kwarg.)

This took me a few hours to debug, so I thought I'd share this with others in case they're trying out this library. I wouldn't merge this as-is due to the PyTorch monkey patch required.

BUT ... with the patches below, I'm able to run on Apple Silicon with a fully modern Python & dependency stack. (The problem with the pinned versions is that there are no wheels of the older binaries for Apple Silicon.)