### PR TITLE
feat(encoder): extract embeddings from transformer encoder after model training

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,15 @@ Can be used for any downstream task, e.g. regression, classification, imputation
 Make sure that the network architecture parameters of the pretrained model match the parameters of the desired fine-tuned model (e.g. use `--d_model 64` for `SpokenArabicDigits`).
 
 ```bash
-python src/main.py --output_dir experiments --comment "pretraining through imputation" --name $1_pretrained --records_file Imputation_records.xls --data_dir /path/to/$1/ --data_class tsra --pattern TRAIN --val_ratio 0.2 --epochs 700 --lr 0.001 --optimizer RAdam --batch_size 32 --pos_encoding learnable --d_model 128
+python src/main.py --output_dir experiments --comment "extract embedding after unsupervised pretraining" --name $1_pretrained --records_file Imputation_records.xls --data_dir /path/to/$1/ --data_class tsra --val_ratio 0 --batch_size 32 --d_model 128 --test_only=testset --load_model=path/to/$1_pretrained/checkpoints/model_best.pth
+```
+
+### Extract embeddings from unsupervised pretrained model
+
+Can be used to extract embeddings after unsupervsied pretraining for time series representation. The results time series representations can be used as features for other machine learning model.
+
+```bash
+python src/main.py --output_dir experiments --comment "pretraining through imputation" --name $1_pretrained --records_file Imputation_records.xls --data_dir /path/to/$1/ --data_class tsra --pattern TRAIN --val_ratio 0.2 --epochs 700 --lr 0.001 --optimizer RAdam --batch_size 32 --pos_encoding learnable --d_model 128  --extract_embeddings_only raw
 ```
 
 As noted above, please check the paper for the optimal hyperparameter values for each dataset. E.g. for pretraining on `BeijingPM25Quality`, one should use `--batch_size 128`.

--- a/src/models/ts_transformer.py
+++ b/src/models/ts_transformer.py
@@ -239,12 +239,13 @@ class TSTransformerEncoder(nn.Module):
         # NOTE: logic for padding masks is reversed to comply with definition in MultiHeadAttention, TransformerEncoderLayer
         output = self.transformer_encoder(inp, src_key_padding_mask=~padding_masks)  # (seq_length, batch_size, d_model)
         output = self.act(output)  # the output transformer encoder/decoder embeddings don't include non-linearity
+        embedding = output
         output = output.permute(1, 0, 2)  # (batch_size, seq_length, d_model)
         output = self.dropout1(output)
         # Most probably defining a Linear(d_model,feat_dim) vectorizes the operation over (seq_length, batch_size).
         output = self.output_layer(output)  # (batch_size, seq_length, feat_dim)
 
-        return output
+        return output, embedding
 
 
 class TSTransformerEncoderClassiregressor(nn.Module):

--- a/src/options.py
+++ b/src/options.py
@@ -163,6 +163,10 @@ class Options(object):
         self.parser.add_argument('--normalization_layer', choices={'BatchNorm', 'LayerNorm'}, default='BatchNorm',
                                  help='Normalization layer to be used internally in transformer encoder')
 
+        # Testing process
+        self.parser.add_argument('--extract_embeddings_only', default='raw',
+                                 help="""If given, will only extract emneddings for the provided test data.""")
+
     def parse(self):
 
         args = self.parser.parse_args()


### PR DESCRIPTION
This update adds the functionality to extract embedding from the transformer encoder after training. These embeddings can be used as features to train other machine learning models and for similarity comparison among other possible use cases.